### PR TITLE
Fix wrong argument type Proc (expected String)

### DIFF
--- a/libraries/provider_database_mysql.rb
+++ b/libraries/provider_database_mysql.rb
@@ -89,7 +89,7 @@ class Chef
 
         action :query do
           begin
-            query_sql = new_resource.sql
+            query_sql = new_resource.sql_query
             Chef::Log.debug("Performing query [#{query_sql}]")
             query_client.query(query_sql)
           ensure


### PR DESCRIPTION
Use `sql_query` attribute instead of `sql` in the mysql provider for
:query action.

Fix #128